### PR TITLE
docs: update README to make reference to packages in scope table

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Security Working Group manages all aspects and processes linked to the Expre
 ### Responsibilities
 
 - Define the Security triage role
-- Define and maintain security policies and procedures for the project and the packages in scope (see [this spreadsheet for scope details](https://docs.google.com/spreadsheets/d/1Qi7B78K6R_RyFloAcrcizL2oYawwMEmdKjgzC_Lik9Q/edit#gid=475621832))
+- Define and maintain security policies and procedures for the project and the packages in scope (see [this table for scope details](https://github.com/expressjs/security-wg/blob/main/tools/scope/packages-in-scope.md))
 - Provide guidance to the ecosystem on how to build more secure middleware
 - Review and recommend processes for handling of security reports.
 - Promote improvement of security practices within the Express project's ecosystem (For example: [OSSF Scorecard](https://github.com/expressjs/discussions/issues/162), threat model, etc..)


### PR DESCRIPTION
## Description

Update `README` file to make reference to the packages in scope list created in [this PR](https://github.com/expressjs/security-wg/pull/10) to replace the Excel sheet that listed all the packages.

In order to merge this PR, first the PR with the table needs to be merged.

## Context

As part of the https://github.com/expressjs/security-wg/issues/2, the first step will be defining the scope and priority of each repo so we can divide efforts when adding the scorecard to each repo. As there is already a proposal to define the scope, if that proposal is merged, the `README` file should be updated accordingly.



