### PR TITLE
feat: add OpenSSF scorecard monitor

### DIFF
--- a/.github/workflows/ossf-scorecard-reporting.yml
+++ b/.github/workflows/ossf-scorecard-reporting.yml
@@ -1,0 +1,51 @@
+name: OpenSSF Scorecard Monitor
+
+on: 
+  # TODO: replace by CRON trigger once a deccision is made
+  # Manual trigger
+  workflow_dispatch:
+
+# Permissions required to run this workflow (create issue and commit/push changes)
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  packages: none
+
+jobs:
+  security-scoring:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: OpenSSF Scorecard Monitor
+        uses: UlisesGascon/openssf-scorecard-monitor@8551177324543b39670fe3c430012c946a937bd1 # v2.0.0-beta7
+
+        with:
+          scope: tools/ossf_scorecard/scope.json
+          database: tools/ossf_scorecard/database.json
+          report: tools/ossf_scorecard/report.md
+          auto-commit: false
+          auto-push: false
+          generate-issue: true
+          issue-title: "OpenSSF Scorecard Report updated!"
+          max-request-in-parallel: 10
+          discovery-enabled: true
+          discovery-orgs: 'expressjs,pillarjs,jshttp'
+          report-tags-enabled: true
+          # The token is needed to create issues, discovery mode and pushing changes in files
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Pull Request
+        uses: gr2m/create-or-update-pull-request-action@2fa38a89a3163b6ee8a76c110d3af2d7325ea9aa # v1.9.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+            commit-message: 'docs: OpenSSF Scorecard Report updated'
+            title: OpenSSF Scorecard Report updated
+            body: 'OpenSSF Scorecard Report updated.'
+            assignees: ${{ github.actor }}
+            labels: security-wg-agenda
+            branch: openssf-scorecard-report-updated
+            update-pull-request-title-and-body: true

--- a/.github/workflows/ossf-scorecard-reporting.yml
+++ b/.github/workflows/ossf-scorecard-reporting.yml
@@ -21,7 +21,6 @@ jobs:
 
       - name: OpenSSF Scorecard Monitor
         uses: UlisesGascon/openssf-scorecard-monitor@8551177324543b39670fe3c430012c946a937bd1 # v2.0.0-beta7
-
         with:
           scope: tools/ossf_scorecard/scope.json
           database: tools/ossf_scorecard/database.json

--- a/tools/ossf_scorecard/scope.json
+++ b/tools/ossf_scorecard/scope.json
@@ -1,0 +1,13 @@
+{
+  "github.com": [
+    {
+      "org": "expressjs"
+    },
+    {
+      "org": "pillarjs"
+    },
+    {
+      "org": "jshttp"
+    }
+  ]
+}


### PR DESCRIPTION
The aim of this pull request is to add the pipeline that runs the [OpenSSF scorecard](https://securityscorecards.dev/) analysis for three organizations (`expressjs`, `pillarjs` and `jshttpg`).

The pull request also creates the folder `tools/ossf_scorecard/` to store the data related (`database.json`, `scope.json` and the `report.md`).

I've configured the pipeline to run manually until de @expressjs/security-wg decides the frequency to run it.

This is based on how it was done for the nodejs organization [here](https://github.com/nodejs/security-wg/blob/main/.github/workflows/ossf-scorecard-reporting.yml).

Once merged and the pipeline is executed, it will create a report similar to [this one](https://github.com/nodejs/security-wg/blob/main/tools/ossf_scorecard/report.md) to easily identify the score for each repo in the 3 organizations along with the difference of score with the previous report and how to improve it.

## Context

- Relates to https://github.com/expressjs/security-wg/issues/2
- Aligned with https://github.com/expressjs/security-wg/issues/1
