### PR TITLE
chore: update scope.json

### DIFF
--- a/tools/ossf_scorecard/scope.json
+++ b/tools/ossf_scorecard/scope.json
@@ -87,11 +87,13 @@
         "content-disposition",
         "http-errors",
         "forwarded",
-        "spdy-push",
         "http-push",
         "mime-db"
       ],
-      "excluded": []
+      "excluded": [
+        "http-utils",
+        "spdy-push"
+      ]
     }
   }
 }

--- a/tools/ossf_scorecard/scope.json
+++ b/tools/ossf_scorecard/scope.json
@@ -7,10 +7,8 @@
         "connect-multiparty",
         "cors",
         "compression",
-        "routification",
         "response-time",
         "basic-auth-connect",
-        "vhostess",
         "generator",
         "multer",
         "body-parser",
@@ -25,14 +23,21 @@
         "session",
         "method-override",
         "morgan",
-        "serve-static",
-        "express-paginate",
-        "mime-extended",
-        "set-type",
-        "api-error-handler",
-        "flash"
+        "serve-static"
       ],
-      "excluded": []
+      "excluded": [
+        "api-error-handler",
+        "connect-markdown",
+        "domain-middleware",
+        "express-expose",
+        "express-paginate",
+        "flash",
+        "mime-extended",
+        "restful-router",
+        "routification",
+        "set-type",
+        "vhostess"
+      ]
     },
     "pillarjs": {
       "included": [
@@ -45,16 +50,18 @@
         "routington",
         "cookies",
         "multiparty",
-        "qs-strict",
         "csrf",
         "router",
         "finalhandler",
-        "ssl-redirect",
-        "templation",
-        "encodeurl",
-        "extend-proto"
+        "encodeurl"
       ],
-      "excluded": []
+      "excluded": [
+        "extend-proto",
+        "qs-strict",
+        "request",
+        "ssl-redirect",
+        "templation"
+      ]
     },
     "jshttp": {
       "included": [


### PR DESCRIPTION
Omit from the scope of the scorecard those repositories that are not worth analyzing either because they are deprecated, totally outdated or because the number of downloads in npm is negligible, so they are candidates to be deprecated in the future.

- [x] api-error-handler - [npm](https://www.npmjs.com/package/api-error-handler)
- [x] connect-markdown - [npm](https://www.npmjs.com/package/connect-markdown)
- [x] domain-middleware - [npm](https://www.npmjs.com/package/domain-middleware)
- [x] express-expose - [npm](https://www.npmjs.com/package/express-expose)
- [x] express-paginate - [npm](https://www.npmjs.com/package/express-paginate)
- [x] flash - [npm](https://www.npmjs.com/package/flash)
- [x] [mime-extended](https://github.com/expressjs/mime-extended) - deprecated
- [x] restful-router - [npm](https://www.npmjs.com/package/restful-router)
- [x] routification - [npm](https://www.npmjs.com/package/routification)
- [x] [set-type](https://github.com/expressjs/set-type) - deprecated
- [x] vhostess - [npm](https://www.npmjs.com/package/vhostess)
- [x] extend-proto - [npm](https://www.npmjs.com/package/extend-proto)
- [x] qs-strict - [npm](https://www.npmjs.com/package/qs-strict)
- [x] [request](https://github.com/pillarjs/request) - no npm package
- [x] ssl-redirect - [npm](https://www.npmjs.com/package/ssl-redirect)
- [x] templation - [npm](https://www.npmjs.com/package/templation)


**Context**

Ref: https://github.com/expressjs/security-wg/issues/2