### PR TITLE
add 'codemod' to the OSSF Scorecard monitoring scope

### DIFF
--- a/tools/ossf_scorecard/scope.json
+++ b/tools/ossf_scorecard/scope.json
@@ -4,6 +4,7 @@
       "included": [
         "expressjs.com",
         "express",
+        "codemod",
         "connect-multiparty",
         "cors",
         "compression",


### PR DESCRIPTION
I believe with this, the data would already be available at https://ossf.github.io/scorecard-visualizer/#/projects/github.com/expressjs/codemod.