### PR TITLE
Nominate @bjohansebas to the Security WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The Security Working Group is composed of two groups of members: the Security Tr
 - [Jean Burellier](https://github.com/sheplu)
 - [Marco Ippolito](https://github.com/marco-ippolito)
 - [Rafael Gonzaga](https://github.com/RafaelGSS)
+- [Sebastian Beltran](https://github.com/bjohansebas)
 - [Ulises Gascón](https://github.com/UlisesGascon)
 - [Wes Todd](https://github.com/wesleytodd)
 


### PR DESCRIPTION
Following our [rules](https://github.com/expressjs/security-wg/blob/main/Contributing.md#how-to-join-the-security-working-group), I would like to nominate @bjohansebas as a member of the Security Working Group.

He is an active contributor to the project and is currently assisting with initiatives such as https://github.com/expressjs/security-wg/issues/2, among other efforts. I believe he can do great things for the group, and he has confirmed his willingness to be nominated.

cc: @expressjs/express-tc @expressjs/security-wg 
