### PR TITLE
fix: update meeting schedule

### DIFF
--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -19,7 +19,7 @@ jobs:
           agendaLabel: 'security-wg-agenda'
           meetingLabels: 'meeting'
             # https://github.com/expressjs/security-wg/issues/28#issuecomment-2399781618
-            # Starting on 2024-10-21 at 5:30pm UTC (2024-10-21T17:30:00.0Z) with a period of 4 weeks (P4W)
-          schedules: '2024-10-21T17:30:00.0Z/P4W'
+            # Starting on 2024-10-21 at 4:30pm UTC (2024-10-21T16:30:00.0Z) with a period of 4 weeks (P4W)
+          schedules: '2025-02-17T16:30:00.0Z/P4W'
           createWithin: 'P1W'
           issueTemplate: 'meeting.md'


### PR DESCRIPTION
The date is changed to ensure they are created correctly since the recurrence was modified, and the time is changed because it seems it will now start an hour earlier—another time change again.

Before months:

![image](https://github.com/user-attachments/assets/2714c73b-0263-4a82-b01a-ae7c5c457645)


Next month:
![image](https://github.com/user-attachments/assets/ed3c0239-19cb-4bf9-9066-c626036a86be)
