### PR TITLE
ci: fix cron to generate reports

### DIFF
--- a/.github/workflows/ossf-scorecard-reporting.yml
+++ b/.github/workflows/ossf-scorecard-reporting.yml
@@ -3,7 +3,7 @@ name: OpenSSF Scorecard Monitor
 on: 
   schedule:
     # Runs on the first Sunday of each month at 00:00 UTC
-    - cron: '0 0 1-7 * 0'
+    - cron: '0 0 1 * 0'
   # Manual trigger
   workflow_dispatch:
 


### PR DESCRIPTION
The issue is that, currently, the cron jobs for generating the scorecard reports are configured to run on the first 7 days of each week, which results in an unnecessary number of issues and PRs. We only need one report per month (see https://github.com/expressjs/security-wg/issues/83 (the important issue), https://github.com/expressjs/security-wg/issues/85, https://github.com/expressjs/security-wg/issues/87).

<img width="487" height="74" alt="imagen" src="https://github.com/user-attachments/assets/7aac55ad-62b2-4451-bb1f-c3994156b385" />

By changing it from 1-7 to 1, it will only run on the first day of the month, which is what we want

<img width="476" height="101" alt="imagen" src="https://github.com/user-attachments/assets/33a8a26f-c477-4da3-9074-645630a8c085" />


ref: https://openjs-foundation.slack.com/archives/C06M4GPDX38/p1751503306545139