### PR TITLE
fix again scorecard report

### DIFF
--- a/.github/workflows/ossf-scorecard-reporting.yml
+++ b/.github/workflows/ossf-scorecard-reporting.yml
@@ -3,7 +3,7 @@ name: OpenSSF Scorecard Monitor
 on: 
   schedule:
     # Runs on the first Sunday of each month at 00:00 UTC
-    - cron: '0 0 1 * 0'
+    - cron: '0 0 1 * *'
   # Manual trigger
   workflow_dispatch:
 


### PR DESCRIPTION
In the previous [PR](https://github.com/expressjs/security-wg/pull/91), I misunderstood the message a bit, and this included every Sunday, which is why it ran again (https://github.com/expressjs/security-wg/pull/100)

prev:
<img width="517" height="86" alt="imagen" src="https://github.com/user-attachments/assets/f2a1ebf9-eef5-46fa-9665-d8fd15c4815f" />

after: 
<img width="508" height="89" alt="imagen" src="https://github.com/user-attachments/assets/b650cb1a-69cb-46a3-b9cd-39e29e995db9" />
