### PR TITLE
Nominate @bjohansebas to the Security Triage team

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The Security Working Group is composed of two groups of members: the Security Tr
 - [Jon Church](https://github.com/jonchurch)
 - [Marco Ippolito](https://github.com/marco-ippolito)
 - [Rafael Gonzaga](https://github.com/RafaelGSS)
+- [Sebastian Beltran](https://github.com/bjohansebas)
 - [Ulises Gascón](https://github.com/UlisesGascon)
 - [Wes Todd](https://github.com/wesleytodd)
 


### PR DESCRIPTION
I’d like to nominate @bjohansebas as a Security Triage Team member, based on his contributions across multiple project areas and his recent involvement in CVE-2025-48997.

cc: @expressjs/express-tc @expressjs/security-triage 