### PR TITLE
Nominate @Phillip9587 to the Security Triage team

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The Security Working Group is composed of two groups of members: the Security Tr
 - [Jordan Harband](https://github.com/ljharb)
 - [Jon Church](https://github.com/jonchurch)
 - [Marco Ippolito](https://github.com/marco-ippolito)
+- [Phillip Barta](https://github.com/Phillip9587)
 - [Rafael Gonzaga](https://github.com/RafaelGSS)
 - [Sebastian Beltran](https://github.com/bjohansebas)
 - [Ulises Gascón](https://github.com/UlisesGascon)


### PR DESCRIPTION
I’d like to nominate @Phillip9587 as a Security Triage Team member, based on his contributions across multiple project areas and his recent involvement in CVE-2025-13466

cc: @expressjs/express-tc @expressjs/security-triage 